### PR TITLE
UTF-8 conversion not required for Python 3

### DIFF
--- a/webnut/webnut.py
+++ b/webnut/webnut.py
@@ -33,7 +33,7 @@ class WebNUT(object):
         try:
             with nut2.PyNUTClient(host=self.server, port=self.port,
                     login=self.username, password=self.password) as client:
-                return client.list_ups()[ups.encode('utf-8')]
+                return client.list_ups()[ups]
         except nut2.PyNUTError:
             return dict()
 
@@ -41,10 +41,10 @@ class WebNUT(object):
         try:
             with nut2.PyNUTClient(host=self.server, port=self.port,
                     login=self.username, password=self.password) as client:
-                ups_vars = client.list_vars(ups.encode('utf-8'))
+                ups_vars = client.list_vars(ups)
                 for var in ups_vars:
                     ups_vars[var] = (ups_vars[var],
-                            client.var_description(ups.encode('utf-8'), var.encode('utf-8')))
+                            client.var_description(ups, var))
                 return (ups_vars, self._get_ups_status(ups_vars))
         except nut2.PyNUTError:
             return (dict(), str())


### PR DESCRIPTION
I was getting this when attempting to view a UPS device:
```
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/waitress/channel.py", line 349, in service
    task.service()
  File "/usr/lib/python3/dist-packages/waitress/task.py", line 169, in service
    self.execute()
  File "/usr/lib/python3/dist-packages/waitress/task.py", line 439, in execute
    app_iter = self.channel.server.application(environ, start_response)
  File "/usr/lib/python3/dist-packages/pyramid/router.py", line 270, in __call__
    response = self.execution_policy(environ, self)
  File "/usr/lib/python3/dist-packages/pyramid/router.py", line 279, in default_execution_policy
    return request.invoke_exception_view(reraise=True)
  File "/usr/lib/python3/dist-packages/pyramid/view.py", line 778, in invoke_exception_view
    reraise_(*exc_info)
  File "/usr/lib/python3/dist-packages/pyramid/compat.py", line 179, in reraise
    raise value
  File "/usr/lib/python3/dist-packages/pyramid/router.py", line 277, in default_execution_policy
    return router.invoke_request(request)
  File "/usr/lib/python3/dist-packages/pyramid/router.py", line 249, in invoke_request
    response = handle_request(request)
  File "/usr/local/lib/python3.8/dist-packages/pyramid_debugtoolbar-4.6.1-py3.8.egg/pyramid_debugtoolbar/toolbar.py", line 223, in toolbar_tween
    return handler(request)
  File "/usr/lib/python3/dist-packages/pyramid/tweens.py", line 43, in excview_tween
    response = _error_handler(request, exc)
  File "/usr/lib/python3/dist-packages/pyramid/tweens.py", line 17, in _error_handler
    reraise(*exc_info)
  File "/usr/lib/python3/dist-packages/pyramid/compat.py", line 179, in reraise
    raise value
  File "/usr/lib/python3/dist-packages/pyramid/tweens.py", line 41, in excview_tween
    response = handler(request)
  File "/usr/lib/python3/dist-packages/pyramid/router.py", line 147, in handle_request
    response = _call_view(
  File "/usr/lib/python3/dist-packages/pyramid/view.py", line 667, in _call_view
    response = view_callable(context, request)
  File "/usr/lib/python3/dist-packages/pyramid/viewderivers.py", line 436, in rendered_view
    result = view(context, request)
  File "/usr/lib/python3/dist-packages/pyramid/viewderivers.py", line 116, in _class_requestonly_view
    response = getattr(inst, attr)()
  File "/usr/local/lib/python3.8/dist-packages/webNUT-0.0.1-py3.8.egg/webnut/views.py", line 24, in ups_view
    ups_name = self.webnut.get_ups_name(ups)
  File "/usr/local/lib/python3.8/dist-packages/webNUT-0.0.1-py3.8.egg/webnut/webnut.py", line 36, in get_ups_name
    return client.list_ups()[ups.encode('utf-8')]
KeyError: b'ups'
```